### PR TITLE
Update clock configuration

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -17,3 +17,9 @@ CONFIG_LOG_BACKEND_UART=n
 CONFIG_CONSOLE=y
 CONFIG_RTT_CONSOLE=y
 CONFIG_ASSERT=y
+
+# Config clock 
+# pan1783_evb and pan1782_evb using internal slow clock. 
+# Please enable following configurations accordingly.
+#CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=y
+#CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=n


### PR DESCRIPTION
Some of the available evaluation boards using just the internal RC for slow clock and not the external XTAL.